### PR TITLE
Fix comment regular expression

### DIFF
--- a/syntaxes/cram.tmLanguage.json
+++ b/syntaxes/cram.tmLanguage.json
@@ -12,7 +12,7 @@
     "repository": {
         "comment": {
             "name": "comment.line.cram",
-            "match": "^[^ ]{2}.*\n$",
+            "match": "^.?[^ ].*\n$",
             "patterns": [
                 {}
             ]


### PR DESCRIPTION
According to https://bitbucket.org/brodie/cram/, any line not begining by two spaces is a comment. This means that any line matching `/^[^ ]/` or `/^.[^ ]/` is a comment. Or, more consisely, `/^.?[^ ]/`.

## Previous behavior
![image](https://user-images.githubusercontent.com/539272/38990665-7c17309c-43db-11e8-956a-fdb4035f4a5f.png)

## New behavior
![image](https://user-images.githubusercontent.com/539272/38990694-95b56ce4-43db-11e8-9225-6297a336b92d.png)
