### PR TITLE
syntax: support heredoc strings properly

### DIFF
--- a/syntaxes/cram.tmLanguage.json
+++ b/syntaxes/cram.tmLanguage.json
@@ -27,6 +27,33 @@
                     "name": "storage.type.function.cram"
                 },
                 {
+                    "begin": "(<<)(\"|'|)\\s*\\\\?([^;&<\\s]+)\\2",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.operator.heredoc.shell"
+                        },
+                        "3": {
+                            "name": "keyword.contro.heredoc-token.shell"
+                        }
+                    },
+                    "end": "^(  > )(\\3)(?=\\s|;|&|$)",
+                    "endCaptures": {
+                        "1": {
+                            "name": "storage.type.function.cram"
+                        },
+                        "3": {
+                            "name": "keyword.control.heredoc-token.shell"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "match": "  > ",
+                            "name": "storage.type.function.cram"
+                        }
+                    ],
+                    "name": "string.unquoted.heredoc.shell"
+                },
+                {
                     "include": "source.shell"
                 }
             ]


### PR DESCRIPTION
Copied `string.unquoted.heredoc.shell` from `shellscript` extension, and adapted it to recognize heredoc syntax properly

## Previous behavior
![image](https://user-images.githubusercontent.com/539272/38990777-d97f23d4-43db-11e8-8dcf-921ba3e1f586.png)

## New behavior
![image](https://user-images.githubusercontent.com/539272/38990798-ec185632-43db-11e8-851a-d26e4e0fc56b.png)
